### PR TITLE
Nominate @zu1k as a go-storage reviewer

### DIFF
--- a/teams.toml
+++ b/teams.toml
@@ -83,6 +83,9 @@ committer = [
     "JinnyYi",
     "Prnyself"
 ]
+reviewer = [
+    "zu1k"
+]
 contributor = [
     "ccamel",
     "zooltd",


### PR DESCRIPTION
@zu1k contributed `go-service-ipfs` implementation https://github.com/beyondstorage/go-service-ipfs/pull/3

Besides this excellent work, he also actively joined discussions in our community, including: 
- https://github.com/beyondstorage/specs/pull/134
- https://github.com/beyondstorage/go-integration-test/pull/27

and made some other contributions, including:
- https://github.com/beyondstorage/go-storage/pull/615
- https://github.com/beyondstorage/go-integration-test/pull/28

So I nominate him as a go-storage reviewer

@beyondstorage/go-storage-leader 
@beyondstorage/go-storage-committer 